### PR TITLE
Updated group test

### DIFF
--- a/architectures/core/__init__.py
+++ b/architectures/core/__init__.py
@@ -311,21 +311,21 @@ class Cluster():
 
 class Group(Cluster):
     """
-    Creates a special type of group used only or organizing nodes.
+    Creates a special type of cluster used only or grouping nodes.
     """
 
     def __init__(self, label="group", **attrs):
 
-        # Set the cluster name
+        # Set the group name
         self.name = "cluster_" + self._rand_id()
 
-        # Set the cluster label
+        # Set the group label
         self.label = label
 
-        # Create cluster
+        # Create group
         self.dot = Digraph(self.name)
 
-        # Set global graph and cluster context
+        # Set global graph and group context
         self._graph = get_graph()
         if self._graph is None:
             raise EnvironmentError("The object is not part of a Graph")
@@ -334,7 +334,7 @@ class Group(Cluster):
         # Update group background color style
         self.dot.graph_attr["style"] = "invis"
 
-        # Set cluster depth
+        # Set group depth
         self._depth = self._cluster._depth + 1 if self._cluster else 0
 
 class Node():

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -4,7 +4,6 @@ import pytest
 
 from architectures.core import Graph, Cluster, Group, Node, Edge, Flow
 from architectures.core import wrap_text
-
 from architectures.themes import Default, LightMode, DarkMode
 
 
@@ -47,6 +46,7 @@ class TestGraph:
             Node("A")
         assert self.default_ext in glob.glob(graph_name + self.default_ext)[0]
 
+    # Do we need this test given the test_theme_overrides test?
     def test_default_theme(self):
         graph_name = "test_theme"
         theme = Default()
@@ -302,17 +302,3 @@ class TestFlow:
             
             with pytest.raises(Exception):
                 Flow([node_a])
-
-# TO-DO
-class TestGroup:
-    @classmethod
-    def setup_class(cls):
-        cls.default_graphname = "my-architecture"
-        cls.default_ext = ".png"
-        cls.default_filename = cls.default_graphname + cls.default_ext
-    
-    @classmethod
-    def teardown_class(cls):
-        for graph_image in glob.glob(f"*{cls.default_ext}"):
-            os.remove(graph_image)
-

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -87,7 +87,7 @@ class TestCluster:
             os.remove(graph_image)
 
     def test_cluster(self):
-        with Graph():
+        with Graph(show=False):
             with Cluster():
                 Node("A")
 
@@ -109,7 +109,7 @@ class TestGroup:
             os.remove(graph_image)
 
     def test_group(self):
-        with Graph():
+        with Graph(show=False):
             with Group():
                 Node("A")
 

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -86,6 +86,11 @@ class TestCluster:
         for graph_image in glob.glob(f"*{cls.default_ext}"):
             os.remove(graph_image)
 
+    def test_cluster(self):
+        with Graph():
+            with Cluster():
+                Node("A")
+
     def test_cluster_graph_context(self):
         with pytest.raises(EnvironmentError):
             Cluster("A")
@@ -102,6 +107,11 @@ class TestGroup:
     def teardown_class(cls):
         for graph_image in glob.glob(f"*{cls.default_ext}"):
             os.remove(graph_image)
+
+    def test_group(self):
+        with Graph():
+            with Group():
+                Node("A")
 
     def test_group_graph_context(self):
         with pytest.raises(EnvironmentError):


### PR DESCRIPTION
The group test was not working because the only test that was happening was whether or not an error would be thrown if a group was not within a graph context.

Tests were updated for clusters and graphs to explicitly create a Cluster and Group under a Graph with a Node within.