### PR TITLE
Edge and Flow ltail and lhead Attributes Configurable

### DIFF
--- a/architectures/core/__init__.py
+++ b/architectures/core/__init__.py
@@ -456,9 +456,6 @@ class Edge():
         # Set edge attributes based on the theme using copy to ensure the objects are independent
         self.edge_attrs = self._graph.theme.edge_attrs.copy()
 
-        # Override any attributes directly passed from the object
-        self.edge_attrs.update(attrs)
-
         if not isinstance(self.start_node, list):
             self.start_node = [self.start_node]
         
@@ -513,6 +510,9 @@ class Edge():
                 else:
                     assert isinstance(self.start_node, (Cluster, Group, Node))
                     assert isinstance(self.end_node, (Cluster, Group, Node))
+
+                # Override any attributes directly passed from the object
+                self.edge_attrs.update(attrs)
 
                 if self.start_node is not None and self.end_node is not None:
                     self._graph.edge(self.start_node, self.end_node, **self.edge_attrs)

--- a/examples/testing.py
+++ b/examples/testing.py
@@ -8,17 +8,13 @@ theme = LightMode()
 with Graph("My Graph", theme=theme):
     with Cluster() as cluster_a:
         with Cluster() as cluster_b:
-            Node()
+            a = Node("A")
+            b = Node("B")
+            c = Node("C")
 
     with Cluster() as cluster_c:
         with Cluster() as cluster_d:
-            Node()
+            d = Node("D")
+            e = Node("E")
 
-    Edge(cluster_a, cluster_c)
-
-
-
-    from architectures.providers.azure.hierarchies import Subscription
-    from architectures.providers.azure.general import Subscription
-
-    Edge(node_a, node_b, ltail=cluster_a._id, lhead=cluster_b._id)
+    Flow([c, e], ltail=cluster_a.name)


### PR DESCRIPTION
Updated the code so that the user can pass in an override to the ltail and lhead attributes.  This is to solve a current problem where you cannot connect an edge to a cluster with no nodes in it based on the current logic.

This addresses issue #53 