### PR TITLE
Cleaned up the Edge object in core and related tests

### DIFF
--- a/examples/testing.py
+++ b/examples/testing.py
@@ -5,7 +5,7 @@ from architectures.themes import Default, LightMode
 
 theme = LightMode(graph_attr_overrides={"rankdir": "TB"})
 
-with Graph("My Graph", theme=theme):
+with Graph("My Graph", theme=theme) as graph:
     with Cluster() as cluster_a:
         with Cluster() as cluster_b:
             node_a = Node("A")
@@ -16,6 +16,4 @@ with Graph("My Graph", theme=theme):
         with Cluster() as cluster_d:
             node_d = Node("D")
 
-    Edge(node_a, cluster_d, ltail=str(cluster_b))
-
-    print(node_a)
+    e = Edge(node_d, cluster_b)

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -259,10 +259,6 @@ class TestEdge:
             edge_b = Edge(cluster_a, cluster_a)
             edge_c = Edge(node_a, cluster_a)
 
-        assert edge_a.start_node is None and edge_a.end_node is None
-        assert edge_b.start_node is None and edge_b.end_node is None
-        assert edge_c.start_node is None and edge_c.end_node is None
-
  
 class TestFlow:
     @classmethod


### PR DESCRIPTION
- changed the context variable __node and related get_node and set_node functions to state to more accurately reflect that it is a map of the "state" of how clusters and groups map to nodes.  this will also eventually be extended to be a complete state of all nested objects.
- updated the get_node_from_cluster function to get_node_obj and the get_cluster_from_node function to get_cluster_obj.  this was done because the function was updated to accept Node or Cluster and Group objects to simplify the Edge logic.
- generally replaced references to nodes or clusters as objs (objects) to make it clear that it did not have to be a Node or Cluster object specifically.  previously this was somewhat confusing.
- updated the test to remove assert since start_node and end_node were no longer being set to None based on the code cleanup.