### PR TITLE
Type Hinting, Pep8 Cleanup, Python Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Architectures comes with support for several providers out-of-the-box.
 ![kubernetes provider](https://img.shields.io/badge/provider-Kubernetes-orange?logo=kubernetes&color=326CE5)
 
 ## Installation
-Architectures works for all version of python greater than version `3.6.x`.  Python can be installed from https://www.python.org/downloads/ or using Homebrew on Mac OS:
+Architectures works for all version of python greater than version `3.7.x`.  Python can be installed from https://www.python.org/downloads/ or using Homebrew on Mac OS:
 ```
 brew install python
 ```
@@ -69,6 +69,8 @@ If you are using a Mac OS for development, you may also have to install the late
 ```
 brew install graphviz
 ```
+If you are using a Windows machine, follow the simplified installation instructions on the [official Graphviz forums](https://forum.graphviz.org/t/new-simplified-installation-procedure-on-windows/224).
+
 It is recommended to use Graphviz version `2.40.x` or later.
 
 ## Core Components
@@ -139,7 +141,7 @@ from architectures.core import Graph, Cluster, Group, Node, Edge, Flow
 ```
 ... or import everything using `*`.
 ```
-rom architectures.core import *
+from architectures.core import *
 ```
 For more information on these objects, see the [Core Components](##core-components) section above.
 ### Part 2 - Creating a Graph

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -8,8 +8,10 @@ Random collection of some things used to LightMode up file names and icons.
 
 path = str(Path(__file__).parent.absolute())
 
+
 def rename_file(file_path):
     os.rename(f, f.lower().replace('-', ' ').replace('(', '').replace(')', ''))
+
 
 def crop_png(png_path):
     im = Image.open(f)
@@ -18,7 +20,8 @@ def crop_png(png_path):
     im2 = im.crop(im.getbbox())
     im2.size  # (214, 178)
     im2.save(png_path)
- 
+
+
 for file in os.listdir(path):
     f = f'{path}/{file}'
     if '.png' in f:

--- a/scripts/generate_providers.py
+++ b/scripts/generate_providers.py
@@ -1,19 +1,20 @@
-  
 import os
 
-heading_text = f'# Do not modify this file directly. It is auto-generated with Python.\n\n'
+heading_text = '# Do not modify this file directly. It is auto-generated with Python.\n\n'
 
 root_dir = os.path.dirname(os.getcwd())
 icons_dir = os.path.join(root_dir, "icons")
 providers_dir = os.path.join(root_dir, "architectures", "providers")
 
+
 def format_text(text):
     return text.replace("-", " ").title().replace(" ", "")
+
 
 init_file = os.path.join(providers_dir, "__init__.py")
 with open(init_file, "w+") as f:
     f.write(heading_text)
-    f.write(f'from architectures.core import Node')
+    f.write('from architectures.core import Node')
 
 providers = os.listdir(icons_dir)
 
@@ -23,7 +24,6 @@ for provider in providers:
         continue
 
     provider_fmt = format_text(provider)
-    
     with open(init_file, "a+") as f:
         f.write(f'\n\nclass _{provider_fmt}(Node):\n')
         f.write(f'    _provider = \"{provider}\"\n')

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
- First pass at type hinting. We use annotations from the future module so that we can annotate functions using our custom class definitions (i.e. Node instead of 'Node'). This functionality is available starting with Python 3.7. See [PEP563](https://www.python.org/dev/peps/pep-0563/#id6).
- Minimum Python version was updated from Python 3.6.X to Python 3.7.X. The built-in module [contextvars was introduced in 3.7](https://docs.python.org/3/whatsnew/3.7.html) and we make use of the annotations functionality in the future module.
- Small PEP8 cleanup using a linter (mainly just spacing between function definitions).
- README was updated with a line for Graphviz installation instructions for Windows machines and to reflect updated Python version requirement.