### PR TITLE
Direct Node Connection When No Labels

### DIFF
--- a/architectures/core/__init__.py
+++ b/architectures/core/__init__.py
@@ -449,9 +449,14 @@ class Node():
         # Override any values directly passed from the object
         self.node_attrs.update(attrs)
 
+        if self.label == "":
+            baseline_padding = 0.0
+        else:
+            baseline_padding = 0.5
+
         # Add attributes specific for when provider service nodes are used.
         if self._icon:
-            padding = 0.1 * (self.label.count('\n'))
+            padding = baseline_padding + (0.15 * (self.label.count('\n')))
             self.node_attrs["height"] = str(float(self.node_attrs['height']) + padding)
             self.node_attrs["image"] = self._load_icon()
 

--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -216,7 +216,7 @@ class LightMode():
             "style": "rounded,filled",
             "fixedsize": "true",
             "width": "1.0",
-            "height": "1.5",
+            "height": "1.0",
             "labelloc": "b",
             "imagescale": "true",
             "fontname": "Calibri",

--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -292,7 +292,7 @@ class DarkMode():
             "style": "rounded,filled",
             "fixedsize": "true",
             "width": "1.0",
-            "height": "1.5",
+            "height": "1.0",
             "labelloc": "b",
             "imagescale": "true",
             "fontname": "Sans-Serif",


### PR DESCRIPTION
Previously, if there was no label at the bottom of a node, the line would still leave a ghostly gap where the text should be.  This was not very sexy at all.  The code for themes and core were updated to accommodate this scenario. 