### PR TITLE
Refactor themes approach

### DIFF
--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -39,10 +39,10 @@ class Default(_Theme):
 
     def __init__(
         self, 
-        graph_settings=None, 
-        cluster_settings=None, 
-        node_settings=None, 
-        edge_settings=None, 
+        graph_settings=None,
+        cluster_settings=None,
+        node_settings=None,
+        edge_settings=None,
         color_settings=None
     ):
         self.graph_attrs = dict(GraphSettings())
@@ -74,22 +74,22 @@ class LightMode(_Theme):
 
     def __init__(
         self, 
-        graph_settings=None, 
-        cluster_settings=None, 
-        node_settings=None, 
-        edge_settings=None, 
+        graph_settings=None,
+        cluster_settings=None,
+        node_settings=None,
+        edge_settings=None,
         color_settings=[]
     ):
 
         self.graph_attrs = dict(GraphSettings(
             bgcolor = "white",
-            compound = "true", 
-            pad = "1.0",
+            compound = True, 
+            pad = 1.0,
             splines = "ortho",
-            nodesep = "1.0",
-            ranksep = "1.0",
-            fontname = "Calibri",
-            fontsize = "24",
+            nodesep = 1.0,
+            ranksep = 1.0,
+            fontname = "calibri",
+            fontsize = 24,
             fontcolor = "#2D3436",
             style = "rounded",
             rankdir = "LR",
@@ -100,28 +100,28 @@ class LightMode(_Theme):
             style = "rounded",
             labeljust = "l",
             pencolor = "#AEB6BE",
-            fontname = "Calibri",
-            fontsize = "12",
-            margin = "30"
+            fontname = "calibri",
+            fontsize = 12,
+            margin = 30
         ))
         self.node_attrs = dict(NodeSettings(
             shape = "invis",
             style = "rounded,filled",
-            fixedsize = "true",
-            width = "1.0",
-            height = "1.0",
+            fixedsize = True,
+            width = 1.0,
+            height = 1.0,
             labelloc = "b",
             imagescale = "true",
-            fontname = "Calibri",
-            fontsize = "13",
+            fontname = "calibri",
+            fontsize = 13,
             fontcolor = "#2D3436",
             color = "invis",
             fillcolor = "invis"
         ))
         self.edge_attrs = dict(EdgeSettings(
-            penwidth = "2",
-            minlen = "2.0",
-            fontname = "Calibri"
+            penwidth = 2,
+            minlen = 2.0,
+            fontname = "calibri"
         ))
         self.colors = ["#FBFBFB", "#EDEDED", "#E0E0E0", "#D3D3D3"]
 
@@ -153,22 +153,22 @@ class DarkMode(_Theme):
 
     def __init__(
         self, 
-        graph_settings=None, 
-        cluster_settings=None, 
-        node_settings=None, 
-        edge_settings=None, 
+        graph_settings=None,
+        cluster_settings=None,
+        node_settings=None,
+        edge_settings=None,
         color_settings=None
     ):
 
         self.graph_attrs = dict(GraphSettings(
             bgcolor = "#17202A",
-            compound = "true", 
-            pad = "1.0",
+            compound = True, 
+            pad = 1.0,
             splines = "ortho",
-            nodesep = "1.0",
-            ranksep = "1.0",
-            fontname = "Sans-Serif",
-            fontsize = "24",
+            nodesep = 1.0,
+            ranksep = 1.0,
+            fontname = "calibri",
+            fontsize = 24,
             fontcolor = "#EEEEEE",
             style = "rounded",
             rankdir = "LR",
@@ -179,28 +179,28 @@ class DarkMode(_Theme):
             style = "rounded,dotted",
             labeljust = "l",
             pencolor = "#AEB6BE",
-            fontname = "Sans-Serif",
-            fontsize = "12",
+            fontname = "calibri",
+            fontsize = 12,
             fontcolor = "#EEEEEE",
-            margin = "30"
+            margin = 30
         ))
         self.node_attrs = dict(NodeSettings(
             shape = "invis",
             style = "rounded,filled",
             fixedsize = "true",
-            width = "1.0",
-            height = "1.0",
+            width = 1.0,
+            height = 1.0,
             labelloc = "b",
-            imagescale = "true",
-            fontname = "Sans-Serif",
-            fontsize = "13",
+            imagescale = True,
+            fontname = "calibri",
+            fontsize = 13,
             fontcolor = "#EEEEEE",
             color = "invis",
             fillcolor = "invis"
         ))
         self.edge_attrs = dict(EdgeSettings(
-            penwidth = "2",
-            minlen = "2.0",
+            penwidth = 2,
+            minlen = 2.0,
             color = "#EEEEEE"
         ))
         self.colors = ["#1C2833", "#212F3D", "#273746", "#2C3E50", "#566573"]

--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -1,330 +1,542 @@
-default_graph_attrs = {
-    "bgcolor": "white",
-    "center": "false",
-    "charset": "utf-8",
-    "clusterrank": "local",
-    "colorscheme": "",
-    "comment": "",
-    "compound": "true",
-    "concentrate": "false",
-    "fontcolor": "black",
-    "fontname": "times-roman",
-    "fontpath": "system-dependent",
-    "fontsize": "14",
-    "forcelabels": "true",
-    "gradientangle": "",
-    "imagepath": "",
-    "label": "",
-    "labeljust": "c",
-    "labelloc": "b",
-    "landscape": "false",
-    "layout": "dot",
-    "margin": "0",
-    "mclimit": "1",
-    "newrank": "false",
-    "nodesep": "0.25",
-    "nojustify": "false",
-    # "nslimit": "",
-    # "nslimit1": "",
-    "ordering": "",
-    "orientation": "0",
-    "outputorder": "breadthfirst",
-    "pack": "false",
-    # "packmode": "node",
-    "pad": "0.0555",
-    "pagedir": "bl",
-    "quantum": "0.0",
-    "rankdir": "TB",
-    "ranksep": "0.5",
-    "ratio": "auto",
-    "remincross": "true",
-    "rotate": "0",
-    "searchsize": "30",
-    "showboxes": "0",
-    "size": "",
-    "sortv": "0",
-    "splines": "line",
-    "style": "",
-    "viewport": "",
-}
+class _Settings():
 
-default_cluster_attrs = {
-    "bgcolor": "transparent",
-    "color": "black",
-    "colorscheme": "",
-    "fillcolor": "black",
-    "fontcolor": "black",
-    "fontname": "times-roman",
-    "fontsize": "14",
-    "gradientangle": "",
-    "label": "",
-    "labeljust": "c",
-    "labelloc": "t",
-    "layer": "",
-    "margin": "8",
-    "nojustify": "false",
-    "pencolor": "black",
-    "penwidth": "1",
-    "peripheries": "1",
-    "sortv": "0",
-    "style": "",
-}
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
 
-default_node_attrs = {
-    "color": "black",
-    "colorscheme": "",
-    "comment": "",
-    "distortion": "0",
-    "fillcolor": "lightgrey",
-    "fixedsize": "false",
-    "fontcolor": "black",
-    "fontname": "times-roman",
-    "fontsize": "14",
-    "gradientangle": "",
-    "group": "",
-    "height": "0.5",
-    # "image": "",
-    "imagepos": "tc",
-    "imagescale": "false",
-    # "label": "",
-    "labelloc": "c",
-    "layer": "",
-    "margin": "0.11,0.055",
-    "nojustify": "false",
-    "ordering": "",
-    "orientation": "0",
-    "penwidth": "1",
-    "peripheries": "1",
-    "pos": "",
-    "regular": "false",
-    "shape": "ellipse",
-    "shapefile": "",
-    "showboxes": "0",
-    "sides": "4",
-    "skew": "0",
-    "sortv": "0",
-    "style": "",
-    "width": "0.75",
-    # "xlabel": "",
-}
+    def __getitem__(self, item):
+        return self.__dict__[item]
 
-default_edge_attrs = {
-    "arrowhead": "normal",
-    "arrowsize": "1",
-    "arrowtail": "normal",
-    "color": "black",
-    "colorscheme": "",
-    "comment": "",
-    "constraint": "true",
-    "decorate": "false",
-    "dir": "forward",
-    "fillcolor": "black",
-    "fontcolor": "black",
-    "fontname": "times-roman",
-    "fontsize": "14",
-    "headclip": "true",
-    "headlabel": "",
-    "headport": "center",
-    "label": "",
-    "labelangle": "-25",
-    "labeldistance": "1",
-    "labelfloat": "false",
-    "labelfontcolor": "black",
-    "labelfontname": "times-roman",
-    "labelfontsize": "14",
-    "layer": "",
-    "lhead": "",
-    "ltail": "",
-    "minlen": "1",
-    "nojustify": "false",
-    "penwidth": "1",
-    "pos": "",
-    "samehead": "",
-    "sametail": "",
-    "showboxes": "0",
-    "style": "",
-    "tailclip": "true",
-    "taillabel": "",
-    "tailport": "center",
-    "weight": "1",
-    "xlabel": "",
-}
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def __iter__(self):
+        return iter(self.__dict__.items())
+class GraphSettings(_Settings):
+    
+    def __init__(
+        self,
+        bgcolor = "white",
+        center = "false",
+        charset = "utf-8",
+        clusterrank = "local",
+        colorscheme = "",
+        comment = "",
+        compound = "true",
+        concentrate = "false",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontpath = "system-dependent",
+        fontsize = "14",
+        forcelabels = "true",
+        gradientangle = "",
+        imagepath = "",
+        label = "",
+        labeljust = "c",
+        labelloc = "b",
+        landscape = "false",
+        layout = "dot",
+        margin = "0",
+        mclimit = "1",
+        newrank = "false",
+        nodesep = "0.25",
+        nojustify = "false",
+        # "nslimit = "",
+        # "nslimit1 = "",
+        ordering = "",
+        orientation = "0",
+        outputorder = "breadthfirst",
+        pack = "false",
+        # "packmode = "node",
+        pad = "0.0555",
+        pagedir = "bl",
+        quantum = "0.0",
+        rankdir = "TB",
+        ranksep = "0.5",
+        ratio = "auto",
+        remincross = "true",
+        rotate = "0",
+        searchsize = "30",
+        showboxes = "0",
+        size = "",
+        sortv = "0",
+        splines = "line",
+        style = "",
+        viewport = "",
+        **kwargs
+    ):
+        self.bgcolor = bgcolor
+        self.center = center
+        self.charset = charset
+        self.clusterrank = clusterrank
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.compound = compound
+        self.concentrate = concentrate
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontpath = fontpath
+        self.fontsize = fontsize
+        self.forcelabels = forcelabels
+        self.gradientangle = gradientangle
+        self.imagepath = imagepath
+        self.label = label
+        self.labeljust = labeljust
+        self.labelloc = labelloc
+        self.landscape = landscape
+        self.layout = layout
+        self.margin = margin
+        self.mclimit = mclimit
+        self.newrank = newrank
+        self.nodesep = nodesep
+        self.nojustify = nojustify
+        # "nslimit = ""
+        # "nslimit1 = ""
+        self.ordering = ordering
+        self.orientation = orientation
+        self.outputorder = outputorder
+        self.pack = pack
+        # "packmode = "node"
+        self.pad = pad
+        self.pagedir = pagedir
+        self.quantum = quantum
+        self.rankdir = rankdir
+        self.ranksep = ranksep
+        self.ratio = ratio
+        self.remincross = remincross
+        self.rotate = rotate
+        self.searchsize = searchsize
+        self.showboxes = showboxes
+        self.size = size
+        self.sortv = sortv
+        self.splines = splines
+        self.style = style
+        self.viewport = viewport
+
+        self.__dict__.update(kwargs)
+
+
+class ClusterSettings(_Settings):
+    def __init__(
+        self,
+        bgcolor = "transparent",
+        color = "black",
+        colorscheme = "",
+        fillcolor = "black",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        gradientangle = "",
+        label = "",
+        labeljust = "c",
+        labelloc = "t",
+        layer = "",
+        margin = "8",
+        nojustify = "false",
+        pencolor = "black",
+        penwidth = "1",
+        peripheries = "1",
+        sortv = "0",
+        style = "",
+        **kwargs
+    ):
+        self.bgcolor = bgcolor
+        self.color = color
+        self.colorscheme = colorscheme
+        self.fillcolor = fillcolor
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.gradientangle = gradientangle
+        self.label = label
+        self.labeljust = labeljust
+        self.labelloc = labelloc
+        self.layer = layer
+        self.margin = margin
+        self.nojustify = nojustify
+        self.pencolor = pencolor
+        self.penwidth = penwidth
+        self.peripheries = peripheries
+        self.sortv = sortv
+        self.style = style
+
+        self.__dict__.update(kwargs)
+
+
+class NodeSettings(_Settings):
+    def __init__(
+        self,
+        color = "black",
+        colorscheme = "",
+        comment = "",
+        distortion = "0",
+        fillcolor = "lightgrey",
+        fixedsize = "false",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        gradientangle = "",
+        group = "",
+        height = "0.5",
+        # image = "",
+        imagepos = "tc",
+        imagescale = "false",
+        # label = "",
+        labelloc = "c",
+        layer = "",
+        margin = "0.11,0.055",
+        nojustify = "false",
+        ordering = "",
+        orientation = "0",
+        penwidth = "1",
+        peripheries = "1",
+        pos = "",
+        regular = "false",
+        shape = "ellipse",
+        shapefile = "",
+        showboxes = "0",
+        sides = "4",
+        skew = "0",
+        sortv = "0",
+        style = "",
+        width = "0.75",
+        # xlabel = "",
+        **kwargs
+    ):
+        self.color = color
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.distortion = distortion
+        self.fillcolor = fillcolor
+        self.fixedsize = fixedsize
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.gradientangle = gradientangle
+        self.group = group
+        self.height = height
+        # self.image = image
+        self.imagepos = imagepos
+        self.imagescale = imagescale
+        # self.label = label
+        self.labelloc = labelloc
+        self.layer = layer
+        self.margin = margin
+        self.nojustify = nojustify
+        self.ordering = ordering
+        self.orientation = orientation
+        self.penwidth = penwidth
+        self.peripheries = peripheries
+        self.pos = pos
+        self.regular = regular
+        self.shape = shape
+        self.shapefile = shapefile
+        self.showboxes = showboxes
+        self.sides = sides
+        self.skew = skew
+        self.sortv = sortv
+        self.style = style
+        self.width = width
+        # self.xlabel = xlabel
+
+        self.__dict__.update(kwargs)
+
+
+class EdgeSettings(_Settings):
+    def __init__(
+        self,
+        arrowhead = "normal",
+        arrowsize = "1",
+        arrowtail = "normal",
+        color = "black",
+        colorscheme = "",
+        comment = "",
+        constraint = "true",
+        decorate = "false",
+        dir = "forward",
+        fillcolor = "black",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        headclip = "true",
+        headlabel = "",
+        headport = "center",
+        label = "",
+        labelangle = "-25",
+        labeldistance = "1",
+        labelfloat = "false",
+        labelfontcolor = "black",
+        labelfontname = "times-roman",
+        labelfontsize = "14",
+        layer = "",
+        lhead = "",
+        ltail = "",
+        minlen = "1",
+        nojustify = "false",
+        penwidth = "1",
+        pos = "",
+        samehead = "",
+        sametail = "",
+        showboxes = "0",
+        style = "",
+        tailclip = "true",
+        taillabel = "",
+        tailport = "center",
+        weight = "1",
+        xlabel = "",
+        **kwargs
+    ):
+        self.arrowhead = arrowhead
+        self.arrowsize =arrowsize
+        self.arrowtail = arrowtail
+        self.color = color
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.constraint = constraint
+        self.decorate = decorate
+        self.dir = dir
+        self.fillcolor = fillcolor
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.headclip = headclip
+        self.headlabel = headlabel
+        self.headport = headport
+        self.label = label
+        self.labelangle = labelangle
+        self.labeldistance = labeldistance
+        self.labelfloat = labelfloat
+        self.labelfontcolor = labelfontcolor
+        self.labelfontname = labelfontname
+        self.labelfontsize = labelfontsize
+        self.layer = layer
+        self.lhead = lhead
+        self.ltail = ltail
+        self.minlen = minlen
+        self.nojustify = nojustify
+        self.penwidth = penwidth
+        self.pos = pos
+        self.samehead = samehead
+        self.sametail = sametail
+        self.showboxes = showboxes
+        self.style = style
+        self.tailclip = tailclip
+        self.taillabel = taillabel
+        self.tailport = tailport
+        self.weight = weight
+        self.xlabel = xlabel
+
+        self.__dict__.update(kwargs)
+
 
 class Default():
 
-    def __init__(self, graph_attr_overrides={}, cluster_attr_overrides={}, node_attr_overrides={}, edge_attr_overrides={}, color_overrides=[]):
-    
-        self.graph_attrs = default_graph_attrs
-        self.cluster_attrs = default_cluster_attrs
-        self.edge_attrs = default_edge_attrs
-        self.node_attrs = default_node_attrs
+    def __init__(
+        self, 
+        graph_settings=None, 
+        cluster_settings=None, 
+        node_settings=None, 
+        edge_settings=None, 
+        color_settings=None
+    ):
+        self.graph_attrs = dict(GraphSettings())
+        self.cluster_attrs = dict(ClusterSettings())
+        self.node_attrs = dict(NodeSettings())
+        self.edge_attrs = dict(EdgeSettings())
         self.colors = []
 
-        if graph_attr_overrides is not None:
-            self.graph_attrs.update(graph_attr_overrides)
+        if graph_settings is not None:
+            self.graph_attrs.update(dict(graph_settings))
 
-        if cluster_attr_overrides is not None:
-            self.cluster_attrs.update(cluster_attr_overrides)
+        if cluster_settings is not None:
+            self.cluster_attrs.update(dict(cluster_settings))
 
-        if node_attr_overrides is not None:
-            self.node_attrs.update(node_attr_overrides)
+        if node_settings is not None:
+            self.node_attrs.update(dict(node_settings))
 
-        if edge_attr_overrides is not None:
-            self.edge_attrs.update(edge_attr_overrides)
+        if edge_settings is not None:
+            self.edge_attrs.update(dict(edge_settings))
 
-        if color_overrides:
-            self.colors = color_overrides
+        if color_settings:
+            self.colors = color_settings
 
 
 class LightMode():
 
-    def __init__(self, graph_attr_overrides={}, cluster_attr_overrides={}, node_attr_overrides={}, edge_attr_overrides={}, color_overrides=[]):
+    def __init__(
+        self, 
+        graph_settings=None, 
+        cluster_settings=None, 
+        node_settings=None, 
+        edge_settings=None, 
+        color_settings=[]
+    ):
 
-        self.graph_attrs = default_graph_attrs
-        self.cluster_attrs = default_cluster_attrs
-        self.edge_attrs = default_edge_attrs
-        self.node_attrs = default_node_attrs
+        self.graph_attrs = dict(GraphSettings(
+            bgcolor = "white",
+            compound = "true", 
+            pad = "1.0",
+            splines = "ortho",
+            nodesep = "1.0",
+            ranksep = "1.0",
+            fontname = "Calibri",
+            fontsize = "24",
+            fontcolor = "#2D3436",
+            style = "rounded",
+            rankdir = "LR",
+            labeljust = "l",
+            labelloc = 't',
+        ))
+        self.cluster_attrs = dict(ClusterSettings(
+            style = "rounded",
+            labeljust = "l",
+            pencolor = "#AEB6BE",
+            fontname = "Calibri",
+            fontsize = "12",
+            margin = "30"
+        ))
+        self.node_attrs = dict(NodeSettings(
+            shape = "invis",
+            style = "rounded,filled",
+            fixedsize = "true",
+            width = "1.0",
+            height = "1.0",
+            labelloc = "b",
+            imagescale = "true",
+            fontname = "Calibri",
+            fontsize = "13",
+            fontcolor = "#2D3436",
+            color = "invis",
+            fillcolor = "invis"
+        ))
+        self.edge_attrs = dict(EdgeSettings(
+            penwidth = "2",
+            minlen = "2.0",
+            fontname = "Calibri"
+        ))
         self.colors = ["#FBFBFB", "#EDEDED", "#E0E0E0", "#D3D3D3"]
 
-        theme_graph_attrs = {
-            "bgcolor": "white",
-            "compound": "true", 
-            "pad": "1.0",
-            "splines": "ortho",
-            "nodesep": "1.0",
-            "ranksep": "1.0",
-            "fontname": "Calibri",
-            "fontsize": "24",
-            "fontcolor": "#2D3436",
-            "style": "rounded",
-            "rankdir": "LR",
-            "labeljust": "l",
-            "labelloc": 't',
-        }
+        _default_settings = Default()
 
-        theme_cluster_attrs = {
-            "style": "rounded",
-            "labeljust": "l",
-            "pencolor": "#AEB6BE",
-            "fontname": "Calibri",
-            "fontsize": "12",
-            "margin": "30"
-        }
+        if graph_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.graph_attrs, dict(graph_settings))
+            self.graph_attrs.update(custom_attrs)
 
-        theme_node_attrs = {
-            "shape": "invis",
-            "style": "rounded,filled",
-            "fixedsize": "true",
-            "width": "1.0",
-            "height": "1.0",
-            "labelloc": "b",
-            "imagescale": "true",
-            "fontname": "Calibri",
-            "fontsize": "13",
-            "fontcolor": "#2D3436",
-            "color": "invis",
-            "fillcolor": "invis"
-        }
+        if cluster_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.cluster_attrs, dict(cluster_settings))
+            self.cluster_attrs.update(custom_attrs)
 
-        theme_edge_attrs = {
-            "penwidth": "2",
-            "minlen": "2.0",
-            "fontname": "Calibri"
-        }
+        if node_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.node_attrs, dict(node_settings))
+            self.node_attrs.update(custom_attrs)
 
-        self.graph_attrs.update(theme_graph_attrs)
-        self.cluster_attrs.update(theme_cluster_attrs)
-        self.node_attrs.update(theme_node_attrs)
-        self.edge_attrs.update(theme_edge_attrs)
+        if edge_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.edge_attrs, dict(edge_settings))
+            self.edge_attrs.update(custom_attrs)
 
-        if graph_attr_overrides is not None:
-            self.graph_attrs.update(graph_attr_overrides)
+        if color_settings:
+            self.colors = color_settings
 
-        if cluster_attr_overrides is not None:
-            self.cluster_attrs.update(cluster_attr_overrides)
+    def get_delta_dict(self, first_dict, second_dict):
+        # create a merged dict
+        merged_dict = {**first_dict, **second_dict}
+        # create a new dict
+        new_dict = {}
+        for k, v in merged_dict.items():
+            if k in first_dict:
+                if first_dict[k] != v:
+                    new_dict[k] = v
+            else:
+                new_dict[k] = v
 
-        if node_attr_overrides is not None:
-            self.node_attrs.update(node_attr_overrides)
-
-        if edge_attr_overrides is not None:
-            self.edge_attrs.update(edge_attr_overrides)
-
-        if color_overrides:
-            self.colors = color_overrides
+        return new_dict
 
 class DarkMode():
 
-    def __init__(self, graph_attr_overrides={}, cluster_attr_overrides={}, node_attr_overrides={}, edge_attr_overrides={}, color_overrides=[]):
+    def __init__(
+        self, 
+        graph_settings=None, 
+        cluster_settings=None, 
+        node_settings=None, 
+        edge_settings=None, 
+        color_settings=None
+    ):
 
-        self.graph_attrs = default_graph_attrs
-        self.cluster_attrs = default_cluster_attrs
-        self.edge_attrs = default_edge_attrs
-        self.node_attrs = default_node_attrs
-        
-        theme_graph_attrs = {
-            "bgcolor": "#17202A",
-            "compound": "true", 
-            "pad": "1.0",
-            "splines": "ortho",
-            "nodesep": "1.0",
-            "ranksep": "1.0",
-            "fontname": "Sans-Serif",
-            "fontsize": "24",
-            "fontcolor": "#EEEEEE",
-            "style": "rounded",
-            "rankdir": "LR",
-            "labeljust": "l",
-            "labelloc": 't',
-        }
-
-        theme_cluster_attrs = {
-            "style": "rounded,dotted",
-            "labeljust": "l",
-            "pencolor": "#AEB6BE",
-            "fontname": "Sans-Serif",
-            "fontsize": "12",
-            "fontcolor": "#EEEEEE",
-            "margin": "30"
-        }
-
-        theme_node_attrs = {
-            "shape": "invis",
-            "style": "rounded,filled",
-            "fixedsize": "true",
-            "width": "1.0",
-            "height": "1.0",
-            "labelloc": "b",
-            "imagescale": "true",
-            "fontname": "Sans-Serif",
-            "fontsize": "13",
-            "fontcolor": "#EEEEEE",
-            "color": "invis",
-            "fillcolor": "invis"
-        }
-
-        theme_edge_attrs = {
-            "penwidth": "2",
-            "minlen": "2.0",
-            "color": "#EEEEEE"
-        }
-
-        self.graph_attrs.update(theme_graph_attrs)
-        self.cluster_attrs.update(theme_cluster_attrs)
-        self.node_attrs.update(theme_node_attrs)
-        self.edge_attrs.update(theme_edge_attrs)
+        self.graph_attrs = dict(GraphSettings(
+            bgcolor = "#17202A",
+            compound = "true", 
+            pad = "1.0",
+            splines = "ortho",
+            nodesep = "1.0",
+            ranksep = "1.0",
+            fontname = "Sans-Serif",
+            fontsize = "24",
+            fontcolor = "#EEEEEE",
+            style = "rounded",
+            rankdir = "LR",
+            labeljust = "l",
+            labelloc = 't',
+        ))
+        self.cluster_attrs = dict(ClusterSettings(
+            style = "rounded,dotted",
+            labeljust = "l",
+            pencolor = "#AEB6BE",
+            fontname = "Sans-Serif",
+            fontsize = "12",
+            fontcolor = "#EEEEEE",
+            margin = "30"
+        ))
+        self.node_attrs = dict(NodeSettings(
+            shape = "invis",
+            style = "rounded,filled",
+            fixedsize = "true",
+            width = "1.0",
+            height = "1.0",
+            labelloc = "b",
+            imagescale = "true",
+            fontname = "Sans-Serif",
+            fontsize = "13",
+            fontcolor = "#EEEEEE",
+            color = "invis",
+            fillcolor = "invis"
+        ))
+        self.edge_attrs = dict(EdgeSettings(
+            penwidth = "2",
+            minlen = "2.0",
+            color = "#EEEEEE"
+        ))
         self.colors = ["#1C2833", "#212F3D", "#273746", "#2C3E50", "#566573"]
 
-        if graph_attr_overrides is not None:
-            self.graph_attrs.update(graph_attr_overrides)
+        _default_settings = Default()
 
-        if cluster_attr_overrides is not None:
-            self.cluster_attrs.update(cluster_attr_overrides)
+        if graph_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.graph_attrs, dict(graph_settings))
+            self.graph_attrs.update(custom_attrs)
 
-        if node_attr_overrides is not None:
-            self.node_attrs.update(node_attr_overrides)
+        if cluster_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.cluster_attrs, dict(cluster_settings))
+            self.cluster_attrs.update(custom_attrs)
 
-        if edge_attr_overrides is not None:
-            self.edge_attrs.update(edge_attr_overrides)
+        if node_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.node_attrs, dict(node_settings))
+            self.node_attrs.update(custom_attrs)
 
-        if color_overrides:
-            self.colors = color_overrides
+        if edge_settings:
+            custom_attrs = self.get_delta_dict(_default_settings.edge_attrs, dict(edge_settings))
+            self.edge_attrs.update(custom_attrs)
+
+        if color_settings:
+            self.colors = color_settings
+
+    def get_delta_dict(self, first_dict, second_dict):
+        # create a merged dict
+        merged_dict = {**first_dict, **second_dict}
+        # create a new dict
+        new_dict = {}
+        for k, v in merged_dict.items():
+            if k in first_dict:
+                if first_dict[k] != v:
+                    new_dict[k] = v
+            else:
+                new_dict[k] = v
+
+        return new_dict

--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -1,4 +1,6 @@
-class _Settings():
+from architectures.themes.settings import GraphSettings, ClusterSettings, NodeSettings, EdgeSettings
+
+class _Theme():
 
     def __setitem__(self, key, value):
         self.__dict__[key] = value
@@ -11,324 +13,22 @@ class _Settings():
 
     def __iter__(self):
         return iter(self.__dict__.items())
-class GraphSettings(_Settings):
-    
-    def __init__(
-        self,
-        bgcolor = "white",
-        center = "false",
-        charset = "utf-8",
-        clusterrank = "local",
-        colorscheme = "",
-        comment = "",
-        compound = "true",
-        concentrate = "false",
-        fontcolor = "black",
-        fontname = "times-roman",
-        fontpath = "system-dependent",
-        fontsize = "14",
-        forcelabels = "true",
-        gradientangle = "",
-        imagepath = "",
-        label = "",
-        labeljust = "c",
-        labelloc = "b",
-        landscape = "false",
-        layout = "dot",
-        margin = "0",
-        mclimit = "1",
-        newrank = "false",
-        nodesep = "0.25",
-        nojustify = "false",
-        # "nslimit = "",
-        # "nslimit1 = "",
-        ordering = "",
-        orientation = "0",
-        outputorder = "breadthfirst",
-        pack = "false",
-        # "packmode = "node",
-        pad = "0.0555",
-        pagedir = "bl",
-        quantum = "0.0",
-        rankdir = "TB",
-        ranksep = "0.5",
-        ratio = "auto",
-        remincross = "true",
-        rotate = "0",
-        searchsize = "30",
-        showboxes = "0",
-        size = "",
-        sortv = "0",
-        splines = "line",
-        style = "",
-        viewport = "",
-        **kwargs
-    ):
-        self.bgcolor = bgcolor
-        self.center = center
-        self.charset = charset
-        self.clusterrank = clusterrank
-        self.colorscheme = colorscheme
-        self.comment = comment
-        self.compound = compound
-        self.concentrate = concentrate
-        self.fontcolor = fontcolor
-        self.fontname = fontname
-        self.fontpath = fontpath
-        self.fontsize = fontsize
-        self.forcelabels = forcelabels
-        self.gradientangle = gradientangle
-        self.imagepath = imagepath
-        self.label = label
-        self.labeljust = labeljust
-        self.labelloc = labelloc
-        self.landscape = landscape
-        self.layout = layout
-        self.margin = margin
-        self.mclimit = mclimit
-        self.newrank = newrank
-        self.nodesep = nodesep
-        self.nojustify = nojustify
-        # "nslimit = ""
-        # "nslimit1 = ""
-        self.ordering = ordering
-        self.orientation = orientation
-        self.outputorder = outputorder
-        self.pack = pack
-        # "packmode = "node"
-        self.pad = pad
-        self.pagedir = pagedir
-        self.quantum = quantum
-        self.rankdir = rankdir
-        self.ranksep = ranksep
-        self.ratio = ratio
-        self.remincross = remincross
-        self.rotate = rotate
-        self.searchsize = searchsize
-        self.showboxes = showboxes
-        self.size = size
-        self.sortv = sortv
-        self.splines = splines
-        self.style = style
-        self.viewport = viewport
 
-        self.__dict__.update(kwargs)
+    def get_delta_dict(self, first_dict, second_dict):
+        # create a merged dict
+        merged_dict = {**first_dict, **second_dict}
+        # create a new dict
+        new_dict = {}
+        for k, v in merged_dict.items():
+            if k in first_dict:
+                if first_dict[k] != v:
+                    new_dict[k] = v
+            else:
+                new_dict[k] = v
 
+        return new_dict
 
-class ClusterSettings(_Settings):
-    def __init__(
-        self,
-        bgcolor = "transparent",
-        color = "black",
-        colorscheme = "",
-        fillcolor = "black",
-        fontcolor = "black",
-        fontname = "times-roman",
-        fontsize = "14",
-        gradientangle = "",
-        label = "",
-        labeljust = "c",
-        labelloc = "t",
-        layer = "",
-        margin = "8",
-        nojustify = "false",
-        pencolor = "black",
-        penwidth = "1",
-        peripheries = "1",
-        sortv = "0",
-        style = "",
-        **kwargs
-    ):
-        self.bgcolor = bgcolor
-        self.color = color
-        self.colorscheme = colorscheme
-        self.fillcolor = fillcolor
-        self.fontcolor = fontcolor
-        self.fontname = fontname
-        self.fontsize = fontsize
-        self.gradientangle = gradientangle
-        self.label = label
-        self.labeljust = labeljust
-        self.labelloc = labelloc
-        self.layer = layer
-        self.margin = margin
-        self.nojustify = nojustify
-        self.pencolor = pencolor
-        self.penwidth = penwidth
-        self.peripheries = peripheries
-        self.sortv = sortv
-        self.style = style
-
-        self.__dict__.update(kwargs)
-
-
-class NodeSettings(_Settings):
-    def __init__(
-        self,
-        color = "black",
-        colorscheme = "",
-        comment = "",
-        distortion = "0",
-        fillcolor = "lightgrey",
-        fixedsize = "false",
-        fontcolor = "black",
-        fontname = "times-roman",
-        fontsize = "14",
-        gradientangle = "",
-        group = "",
-        height = "0.5",
-        # image = "",
-        imagepos = "tc",
-        imagescale = "false",
-        # label = "",
-        labelloc = "c",
-        layer = "",
-        margin = "0.11,0.055",
-        nojustify = "false",
-        ordering = "",
-        orientation = "0",
-        penwidth = "1",
-        peripheries = "1",
-        pos = "",
-        regular = "false",
-        shape = "ellipse",
-        shapefile = "",
-        showboxes = "0",
-        sides = "4",
-        skew = "0",
-        sortv = "0",
-        style = "",
-        width = "0.75",
-        # xlabel = "",
-        **kwargs
-    ):
-        self.color = color
-        self.colorscheme = colorscheme
-        self.comment = comment
-        self.distortion = distortion
-        self.fillcolor = fillcolor
-        self.fixedsize = fixedsize
-        self.fontcolor = fontcolor
-        self.fontname = fontname
-        self.fontsize = fontsize
-        self.gradientangle = gradientangle
-        self.group = group
-        self.height = height
-        # self.image = image
-        self.imagepos = imagepos
-        self.imagescale = imagescale
-        # self.label = label
-        self.labelloc = labelloc
-        self.layer = layer
-        self.margin = margin
-        self.nojustify = nojustify
-        self.ordering = ordering
-        self.orientation = orientation
-        self.penwidth = penwidth
-        self.peripheries = peripheries
-        self.pos = pos
-        self.regular = regular
-        self.shape = shape
-        self.shapefile = shapefile
-        self.showboxes = showboxes
-        self.sides = sides
-        self.skew = skew
-        self.sortv = sortv
-        self.style = style
-        self.width = width
-        # self.xlabel = xlabel
-
-        self.__dict__.update(kwargs)
-
-
-class EdgeSettings(_Settings):
-    def __init__(
-        self,
-        arrowhead = "normal",
-        arrowsize = "1",
-        arrowtail = "normal",
-        color = "black",
-        colorscheme = "",
-        comment = "",
-        constraint = "true",
-        decorate = "false",
-        dir = "forward",
-        fillcolor = "black",
-        fontcolor = "black",
-        fontname = "times-roman",
-        fontsize = "14",
-        headclip = "true",
-        headlabel = "",
-        headport = "center",
-        label = "",
-        labelangle = "-25",
-        labeldistance = "1",
-        labelfloat = "false",
-        labelfontcolor = "black",
-        labelfontname = "times-roman",
-        labelfontsize = "14",
-        layer = "",
-        lhead = "",
-        ltail = "",
-        minlen = "1",
-        nojustify = "false",
-        penwidth = "1",
-        pos = "",
-        samehead = "",
-        sametail = "",
-        showboxes = "0",
-        style = "",
-        tailclip = "true",
-        taillabel = "",
-        tailport = "center",
-        weight = "1",
-        xlabel = "",
-        **kwargs
-    ):
-        self.arrowhead = arrowhead
-        self.arrowsize =arrowsize
-        self.arrowtail = arrowtail
-        self.color = color
-        self.colorscheme = colorscheme
-        self.comment = comment
-        self.constraint = constraint
-        self.decorate = decorate
-        self.dir = dir
-        self.fillcolor = fillcolor
-        self.fontcolor = fontcolor
-        self.fontname = fontname
-        self.fontsize = fontsize
-        self.headclip = headclip
-        self.headlabel = headlabel
-        self.headport = headport
-        self.label = label
-        self.labelangle = labelangle
-        self.labeldistance = labeldistance
-        self.labelfloat = labelfloat
-        self.labelfontcolor = labelfontcolor
-        self.labelfontname = labelfontname
-        self.labelfontsize = labelfontsize
-        self.layer = layer
-        self.lhead = lhead
-        self.ltail = ltail
-        self.minlen = minlen
-        self.nojustify = nojustify
-        self.penwidth = penwidth
-        self.pos = pos
-        self.samehead = samehead
-        self.sametail = sametail
-        self.showboxes = showboxes
-        self.style = style
-        self.tailclip = tailclip
-        self.taillabel = taillabel
-        self.tailport = tailport
-        self.weight = weight
-        self.xlabel = xlabel
-
-        self.__dict__.update(kwargs)
-
-
-class Default():
+class Default(_Theme):
 
     def __init__(
         self, 
@@ -360,7 +60,7 @@ class Default():
             self.colors = color_settings
 
 
-class LightMode():
+class LightMode(_Theme):
 
     def __init__(
         self, 
@@ -436,21 +136,7 @@ class LightMode():
         if color_settings:
             self.colors = color_settings
 
-    def get_delta_dict(self, first_dict, second_dict):
-        # create a merged dict
-        merged_dict = {**first_dict, **second_dict}
-        # create a new dict
-        new_dict = {}
-        for k, v in merged_dict.items():
-            if k in first_dict:
-                if first_dict[k] != v:
-                    new_dict[k] = v
-            else:
-                new_dict[k] = v
-
-        return new_dict
-
-class DarkMode():
+class DarkMode(_Theme):
 
     def __init__(
         self, 

--- a/architectures/themes/__init__.py
+++ b/architectures/themes/__init__.py
@@ -15,6 +15,10 @@ class _Theme():
         return iter(self.__dict__.items())
 
     def get_delta_dict(self, first_dict, second_dict):
+        """
+        Compare two dictionaries and return a new dictionary
+        that contains same keys with different values or new keys.
+        """
         # create a merged dict
         merged_dict = {**first_dict, **second_dict}
         # create a new dict
@@ -29,6 +33,9 @@ class _Theme():
         return new_dict
 
 class Default(_Theme):
+    """
+    The Graphviz default theme.
+    """
 
     def __init__(
         self, 
@@ -61,6 +68,9 @@ class Default(_Theme):
 
 
 class LightMode(_Theme):
+    """
+    A clean, light theme for general diagram creation.
+    """
 
     def __init__(
         self, 
@@ -137,6 +147,9 @@ class LightMode(_Theme):
             self.colors = color_settings
 
 class DarkMode(_Theme):
+    """
+    A dark mode version of lightmode
+    """
 
     def __init__(
         self, 
@@ -212,17 +225,3 @@ class DarkMode(_Theme):
 
         if color_settings:
             self.colors = color_settings
-
-    def get_delta_dict(self, first_dict, second_dict):
-        # create a merged dict
-        merged_dict = {**first_dict, **second_dict}
-        # create a new dict
-        new_dict = {}
-        for k, v in merged_dict.items():
-            if k in first_dict:
-                if first_dict[k] != v:
-                    new_dict[k] = v
-            else:
-                new_dict[k] = v
-
-        return new_dict

--- a/architectures/themes/settings/__init__.py
+++ b/architectures/themes/settings/__init__.py
@@ -1,0 +1,330 @@
+class _Settings():
+
+    def __setitem__(self, key, value):
+        self.__dict__[key] = value
+
+    def __getitem__(self, item):
+        return self.__dict__[item]
+
+    def __repr__(self):
+        return str(self.__dict__)
+
+    def __iter__(self):
+        return iter(self.__dict__.items())
+
+
+class GraphSettings(_Settings):
+    
+    def __init__(
+        self,
+        bgcolor = "white",
+        center = "false",
+        charset = "utf-8",
+        clusterrank = "local",
+        colorscheme = "",
+        comment = "",
+        compound = "true",
+        concentrate = "false",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontpath = "system-dependent",
+        fontsize = "14",
+        forcelabels = "true",
+        gradientangle = "",
+        imagepath = "",
+        label = "",
+        labeljust = "c",
+        labelloc = "b",
+        landscape = "false",
+        layout = "dot",
+        margin = "0",
+        mclimit = "1",
+        newrank = "false",
+        nodesep = "0.25",
+        nojustify = "false",
+        # "nslimit = "",
+        # "nslimit1 = "",
+        ordering = "",
+        orientation = "0",
+        outputorder = "breadthfirst",
+        pack = "false",
+        # "packmode = "node",
+        pad = "0.0555",
+        pagedir = "bl",
+        quantum = "0.0",
+        rankdir = "TB",
+        ranksep = "0.5",
+        ratio = "auto",
+        remincross = "true",
+        rotate = "0",
+        searchsize = "30",
+        showboxes = "0",
+        size = "",
+        sortv = "0",
+        splines = "line",
+        style = "",
+        viewport = "",
+        **kwargs
+    ):
+        self.bgcolor = bgcolor
+        self.center = center
+        self.charset = charset
+        self.clusterrank = clusterrank
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.compound = compound
+        self.concentrate = concentrate
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontpath = fontpath
+        self.fontsize = fontsize
+        self.forcelabels = forcelabels
+        self.gradientangle = gradientangle
+        self.imagepath = imagepath
+        self.label = label
+        self.labeljust = labeljust
+        self.labelloc = labelloc
+        self.landscape = landscape
+        self.layout = layout
+        self.margin = margin
+        self.mclimit = mclimit
+        self.newrank = newrank
+        self.nodesep = nodesep
+        self.nojustify = nojustify
+        # "nslimit = ""
+        # "nslimit1 = ""
+        self.ordering = ordering
+        self.orientation = orientation
+        self.outputorder = outputorder
+        self.pack = pack
+        # "packmode = "node"
+        self.pad = pad
+        self.pagedir = pagedir
+        self.quantum = quantum
+        self.rankdir = rankdir
+        self.ranksep = ranksep
+        self.ratio = ratio
+        self.remincross = remincross
+        self.rotate = rotate
+        self.searchsize = searchsize
+        self.showboxes = showboxes
+        self.size = size
+        self.sortv = sortv
+        self.splines = splines
+        self.style = style
+        self.viewport = viewport
+
+        self.__dict__.update(kwargs)
+
+
+class ClusterSettings(_Settings):
+    def __init__(
+        self,
+        bgcolor = "transparent",
+        color = "black",
+        colorscheme = "",
+        fillcolor = "black",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        gradientangle = "",
+        label = "",
+        labeljust = "c",
+        labelloc = "t",
+        layer = "",
+        margin = "8",
+        nojustify = "false",
+        pencolor = "black",
+        penwidth = "1",
+        peripheries = "1",
+        sortv = "0",
+        style = "",
+        **kwargs
+    ):
+        self.bgcolor = bgcolor
+        self.color = color
+        self.colorscheme = colorscheme
+        self.fillcolor = fillcolor
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.gradientangle = gradientangle
+        self.label = label
+        self.labeljust = labeljust
+        self.labelloc = labelloc
+        self.layer = layer
+        self.margin = margin
+        self.nojustify = nojustify
+        self.pencolor = pencolor
+        self.penwidth = penwidth
+        self.peripheries = peripheries
+        self.sortv = sortv
+        self.style = style
+
+        self.__dict__.update(kwargs)
+
+
+class NodeSettings(_Settings):
+    def __init__(
+        self,
+        color = "black",
+        colorscheme = "",
+        comment = "",
+        distortion = "0",
+        fillcolor = "lightgrey",
+        fixedsize = "false",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        gradientangle = "",
+        group = "",
+        height = "0.5",
+        # image = "",
+        imagepos = "tc",
+        imagescale = "false",
+        # label = "",
+        labelloc = "c",
+        layer = "",
+        margin = "0.11,0.055",
+        nojustify = "false",
+        ordering = "",
+        orientation = "0",
+        penwidth = "1",
+        peripheries = "1",
+        pos = "",
+        regular = "false",
+        shape = "ellipse",
+        shapefile = "",
+        showboxes = "0",
+        sides = "4",
+        skew = "0",
+        sortv = "0",
+        style = "",
+        width = "0.75",
+        # xlabel = "",
+        **kwargs
+    ):
+        self.color = color
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.distortion = distortion
+        self.fillcolor = fillcolor
+        self.fixedsize = fixedsize
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.gradientangle = gradientangle
+        self.group = group
+        self.height = height
+        # self.image = image
+        self.imagepos = imagepos
+        self.imagescale = imagescale
+        # self.label = label
+        self.labelloc = labelloc
+        self.layer = layer
+        self.margin = margin
+        self.nojustify = nojustify
+        self.ordering = ordering
+        self.orientation = orientation
+        self.penwidth = penwidth
+        self.peripheries = peripheries
+        self.pos = pos
+        self.regular = regular
+        self.shape = shape
+        self.shapefile = shapefile
+        self.showboxes = showboxes
+        self.sides = sides
+        self.skew = skew
+        self.sortv = sortv
+        self.style = style
+        self.width = width
+        # self.xlabel = xlabel
+
+        self.__dict__.update(kwargs)
+
+
+class EdgeSettings(_Settings):
+    def __init__(
+        self,
+        arrowhead = "normal",
+        arrowsize = "1",
+        arrowtail = "normal",
+        color = "black",
+        colorscheme = "",
+        comment = "",
+        constraint = "true",
+        decorate = "false",
+        dir = "forward",
+        fillcolor = "black",
+        fontcolor = "black",
+        fontname = "times-roman",
+        fontsize = "14",
+        headclip = "true",
+        headlabel = "",
+        headport = "center",
+        label = "",
+        labelangle = "-25",
+        labeldistance = "1",
+        labelfloat = "false",
+        labelfontcolor = "black",
+        labelfontname = "times-roman",
+        labelfontsize = "14",
+        layer = "",
+        lhead = "",
+        ltail = "",
+        minlen = "1",
+        nojustify = "false",
+        penwidth = "1",
+        pos = "",
+        samehead = "",
+        sametail = "",
+        showboxes = "0",
+        style = "",
+        tailclip = "true",
+        taillabel = "",
+        tailport = "center",
+        weight = "1",
+        xlabel = "",
+        **kwargs
+    ):
+        self.arrowhead = arrowhead
+        self.arrowsize =arrowsize
+        self.arrowtail = arrowtail
+        self.color = color
+        self.colorscheme = colorscheme
+        self.comment = comment
+        self.constraint = constraint
+        self.decorate = decorate
+        self.dir = dir
+        self.fillcolor = fillcolor
+        self.fontcolor = fontcolor
+        self.fontname = fontname
+        self.fontsize = fontsize
+        self.headclip = headclip
+        self.headlabel = headlabel
+        self.headport = headport
+        self.label = label
+        self.labelangle = labelangle
+        self.labeldistance = labeldistance
+        self.labelfloat = labelfloat
+        self.labelfontcolor = labelfontcolor
+        self.labelfontname = labelfontname
+        self.labelfontsize = labelfontsize
+        self.layer = layer
+        self.lhead = lhead
+        self.ltail = ltail
+        self.minlen = minlen
+        self.nojustify = nojustify
+        self.penwidth = penwidth
+        self.pos = pos
+        self.samehead = samehead
+        self.sametail = sametail
+        self.showboxes = showboxes
+        self.style = style
+        self.tailclip = tailclip
+        self.taillabel = taillabel
+        self.tailport = tailport
+        self.weight = weight
+        self.xlabel = xlabel
+
+        self.__dict__.update(kwargs)

--- a/architectures/themes/settings/__init__.py
+++ b/architectures/themes/settings/__init__.py
@@ -1,5 +1,8 @@
 class _Settings():
 
+    # Validation values
+    _dir_settings = ["forward", "back", "both", "none"]
+
     def __setitem__(self, key, value):
         self.__dict__[key] = value
 
@@ -11,6 +14,9 @@ class _Settings():
 
     def __iter__(self):
         return iter(self.__dict__.items())
+
+    def check_string_settings(self, setting: str, valid_settings: list) -> bool:
+        return setting in valid_settings
 
 
 class GraphSettings(_Settings):
@@ -347,6 +353,11 @@ class EdgeSettings(_Settings):
 
         # Add any additional keyword arguments
         self.__dict__.update(kwargs)
+
+        # Check dir settings
+        # _field = "dir"
+        # if not self.check_string_settings(dict(self)["dir"], self._dir_settings):
+        #     raise ValueError(f"The field {_field} must be one of the following: {', '.join(self._dir_settings)}")
 
         # Ensure that all values for attributes are strings
         for k, v in self.__dict__.items():

--- a/architectures/themes/settings/__init__.py
+++ b/architectures/themes/settings/__init__.py
@@ -23,44 +23,44 @@ class GraphSettings(_Settings):
         clusterrank = "local",
         colorscheme = "",
         comment = "",
-        compound = "true",
-        concentrate = "false",
+        compound = True,
+        concentrate = False,
         fontcolor = "black",
         fontname = "times-roman",
         fontpath = "system-dependent",
-        fontsize = "14",
-        forcelabels = "true",
-        gradientangle = "",
+        fontsize = 14,
+        forcelabels = True,
+        gradientangle = 0,
         imagepath = "",
         label = "",
         labeljust = "c",
         labelloc = "b",
-        landscape = "false",
+        landscape = False,
         layout = "dot",
-        margin = "0",
-        mclimit = "1",
-        newrank = "false",
-        nodesep = "0.25",
-        nojustify = "false",
+        margin = 0,
+        mclimit = 1,
+        newrank = False,
+        nodesep = 0.25,
+        nojustify = False,
         # "nslimit = "",
         # "nslimit1 = "",
         ordering = "",
-        orientation = "0",
+        orientation = 0,
         outputorder = "breadthfirst",
-        pack = "false",
+        pack = False,
         # "packmode = "node",
-        pad = "0.0555",
+        pad = 0.0555,
         pagedir = "bl",
-        quantum = "0.0",
+        quantum = 0.0,
         rankdir = "TB",
-        ranksep = "0.5",
+        ranksep = 0.5,
         ratio = "auto",
-        remincross = "true",
-        rotate = "0",
-        searchsize = "30",
-        showboxes = "0",
-        size = "",
-        sortv = "0",
+        remincross = True,
+        rotate = 0,
+        searchsize = 30,
+        showboxes = 0,
+        size = 100.0,
+        sortv = 0,
         splines = "line",
         style = "",
         viewport = "",
@@ -114,7 +114,13 @@ class GraphSettings(_Settings):
         self.style = style
         self.viewport = viewport
 
+        # Add any additional keyword arguments
         self.__dict__.update(kwargs)
+
+        # Ensure that all values for attributes are strings
+        for k, v in self.__dict__.items():
+            if not isinstance(v, str):
+                self.__dict__[k] = str(v).lower().lower()
 
 
 class ClusterSettings(_Settings):
@@ -126,18 +132,18 @@ class ClusterSettings(_Settings):
         fillcolor = "black",
         fontcolor = "black",
         fontname = "times-roman",
-        fontsize = "14",
-        gradientangle = "",
+        fontsize = 14,
+        gradientangle = 0,
         label = "",
         labeljust = "c",
         labelloc = "t",
         layer = "",
-        margin = "8",
-        nojustify = "false",
+        margin = 8,
+        nojustify = False,
         pencolor = "black",
-        penwidth = "1",
-        peripheries = "1",
-        sortv = "0",
+        penwidth = 1,
+        peripheries = 1,
+        sortv = 0,
         style = "",
         **kwargs
     ):
@@ -161,7 +167,13 @@ class ClusterSettings(_Settings):
         self.sortv = sortv
         self.style = style
 
+        # Add any additional keyword arguments
         self.__dict__.update(kwargs)
+
+        # Ensure that all values for attributes are strings
+        for k, v in self.__dict__.items():
+            if not isinstance(v, str):
+                self.__dict__[k] = str(v).lower()
 
 
 class NodeSettings(_Settings):
@@ -170,37 +182,37 @@ class NodeSettings(_Settings):
         color = "black",
         colorscheme = "",
         comment = "",
-        distortion = "0",
+        distortion = 0,
         fillcolor = "lightgrey",
-        fixedsize = "false",
+        fixedsize = False,
         fontcolor = "black",
         fontname = "times-roman",
-        fontsize = "14",
-        gradientangle = "",
+        fontsize = 14,
+        gradientangle = 0,
         group = "",
-        height = "0.5",
+        height = 0.5,
         # image = "",
         imagepos = "tc",
-        imagescale = "false",
+        imagescale = False,
         # label = "",
         labelloc = "c",
         layer = "",
         margin = "0.11,0.055",
-        nojustify = "false",
+        nojustify = False,
         ordering = "",
-        orientation = "0",
-        penwidth = "1",
-        peripheries = "1",
+        orientation = 0,
+        penwidth = 1,
+        peripheries = 1,
         pos = "",
-        regular = "false",
+        regular = False,
         shape = "ellipse",
         shapefile = "",
-        showboxes = "0",
-        sides = "4",
-        skew = "0",
-        sortv = "0",
+        showboxes = 0,
+        sides = 4,
+        skew = 0,
+        sortv = 0,
         style = "",
-        width = "0.75",
+        width = 0.75,
         # xlabel = "",
         **kwargs
     ):
@@ -240,50 +252,56 @@ class NodeSettings(_Settings):
         self.width = width
         # self.xlabel = xlabel
 
+        # Add any additional keyword arguments
         self.__dict__.update(kwargs)
+
+        # Ensure that all values for attributes are strings
+        for k, v in self.__dict__.items():
+            if not isinstance(v, str):
+                self.__dict__[k] = str(v).lower()
 
 
 class EdgeSettings(_Settings):
     def __init__(
         self,
         arrowhead = "normal",
-        arrowsize = "1",
+        arrowsize = 1,
         arrowtail = "normal",
         color = "black",
         colorscheme = "",
         comment = "",
-        constraint = "true",
-        decorate = "false",
+        constraint = True,
+        decorate = False,
         dir = "forward",
         fillcolor = "black",
         fontcolor = "black",
         fontname = "times-roman",
-        fontsize = "14",
-        headclip = "true",
+        fontsize = 14,
+        headclip = True,
         headlabel = "",
         headport = "center",
         label = "",
-        labelangle = "-25",
-        labeldistance = "1",
-        labelfloat = "false",
+        labelangle = -25,
+        labeldistance = 1,
+        labelfloat = False,
         labelfontcolor = "black",
         labelfontname = "times-roman",
-        labelfontsize = "14",
+        labelfontsize = 14,
         layer = "",
         lhead = "",
         ltail = "",
-        minlen = "1",
-        nojustify = "false",
-        penwidth = "1",
+        minlen = 1,
+        nojustify = False,
+        penwidth = 1,
         pos = "",
         samehead = "",
         sametail = "",
-        showboxes = "0",
+        showboxes = 0,
         style = "",
-        tailclip = "true",
+        tailclip = True,
         taillabel = "",
         tailport = "center",
-        weight = "1",
+        weight = 1,
         xlabel = "",
         **kwargs
     ):
@@ -327,4 +345,10 @@ class EdgeSettings(_Settings):
         self.weight = weight
         self.xlabel = xlabel
 
+        # Add any additional keyword arguments
         self.__dict__.update(kwargs)
+
+        # Ensure that all values for attributes are strings
+        for k, v in self.__dict__.items():
+            if not isinstance(v, str):
+                self.__dict__[k] = str(v).lower()

--- a/examples/intelligent-search.py
+++ b/examples/intelligent-search.py
@@ -1,5 +1,5 @@
 from architectures.core import Graph, Cluster, Node, Edge, Flow
-from architectures.themes import DarkMode, LightMode
+from architectures.themes import DarkMode, LightMode, GraphSettings
 
 from architectures.providers.azure.general import Computer
 from architectures.providers.azure.application import ApplicationService
@@ -7,7 +7,8 @@ from architectures.providers.azure.ai import BotService, CognitiveServicesSearch
 from architectures.providers.azure.data import SqlDatabase
 from architectures.providers.azure.compute import VirtualMachine
 
-theme = DarkMode(graph_attr_overrides={"nodesep":"3"})
+graph_settings = GraphSettings(bgcolor="blue")
+theme = LightMode(graph_settings=graph_settings)
 
 with Graph("Intelligent Search", theme=theme):
     computer = Computer()

--- a/examples/intelligent-search.py
+++ b/examples/intelligent-search.py
@@ -7,7 +7,7 @@ from architectures.providers.azure.ai import BotService, CognitiveServicesSearch
 from architectures.providers.azure.data import SqlDatabase
 from architectures.providers.azure.compute import VirtualMachine
 
-graph_settings = GraphSettings(bgcolor="blue")
+graph_settings = GraphSettings(nodesep="3")
 theme = LightMode(graph_settings=graph_settings)
 
 with Graph("Intelligent Search", theme=theme):

--- a/examples/neural-network.py
+++ b/examples/neural-network.py
@@ -1,7 +1,7 @@
 from architectures.core import Graph, Cluster, Node, Edge, Flow
 from architectures.themes import Default, LightMode
 
-theme = LightMode(graph_attr_overrides={"splines":"false"})
+theme = LightMode(graph_settings={"splines":"false"})
 
 with Graph("Neural Network", theme=theme):
     input_layer = [Node() for i in range(3)]

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -5,7 +5,7 @@ from architectures.providers.azure.data import DataLake, SqlServer
 from architectures.providers.azure.compute import VirtualMachine
 from architectures.providers.azure.networking import ApplicationGateway
 
-theme = LightMode(graph_attr_overrides={"rankdir":"TB"})
+theme = LightMode(graph_settings={"rankdir":"TB"})
 
 with Graph("Simple", theme=theme):
     app_gateway = ApplicationGateway()

--- a/tests/test_architectures.py
+++ b/tests/test_architectures.py
@@ -64,11 +64,11 @@ class TestGraph:
         graph_name = "test_theme_overrides"
         color = "#FFFFFF"
         kwargs = {
-            "graph_attr_overrides": {"bgcolor":color},
-            "cluster_attr_overrides": {"bgcolor":color},
-            "node_attr_overrides": {"color":color},
-            "edge_attr_overrides": {"color":color},
-            "color_overrides": [color]}
+            "graph_settings": {"bgcolor":color},
+            "cluster_settings": {"bgcolor":color},
+            "node_settings": {"color":color},
+            "edge_settings": {"color":color},
+            "color_settings": [color]}
         themes = [Default(**kwargs), LightMode(**kwargs), DarkMode(**kwargs)]
         for theme in themes:
             with Graph(graph_name, theme=theme, show=False) as graph:


### PR DESCRIPTION
The purpose of this pull request is to implement a new concept called settings.  Settings allow users to great a settings object that has all of the relevant attributes for that setting domain (Graph, Cluster, Node, Edge).  This will help users to better understand what attributes are available.  Settings can be imported as follows:

`from architectures.themes.settings import GraphSettings, ClusterSettings, NodeSettings, EdgeSettings`

Themes were updated to remove the old dictionary maps and get all details about settings using these new objects.  A function was also created to get the delta between user specified options and the default options so that only those attributes are set over top of a theme.

This change is actually backwards compatible meaning that the following are equivalent:

** New Way **
```
from architectures.core import Graph
from architectures.themes import LightMode
from architectures.themes.settings import GraphSettings

graph_settings = GraphSettings(nodesep=3)
theme = LightMode(graph_settings=graph_settings)

with Graph(theme=theme):
    pass
```
** Old Way **
```
from architectures.core import Graph
from architectures.themes import LightMode

theme = LightMode(graph_settings={"nodesep":"3"})

with Graph(theme=theme):
    pass
```
At first, the new way may seem more complex, but it actually offers some benefits including:
* you can simply specify keyword arguments in the new class
* because all attributes are in the class, it is easy to know what attributes are valid for the object
* you can pass the actual object type rather than a string (e.g. True rather than "true")
* doing this allows for validation of values passed to attributes and terminal output to let you know what valid values are accepted