### PR TITLE
Test updating packages to include substrees

### DIFF
--- a/architectures/providers/aws/__init__.py
+++ b/architectures/providers/aws/__init__.py
@@ -1,1 +1,0 @@
-# Make sure Python can find the packages

--- a/architectures/providers/azure/__init__.py
+++ b/architectures/providers/azure/__init__.py
@@ -1,5 +1,0 @@
-from architectures.core import Node
-
-class _Azure(Node):
-    _provider = "azure"
-    _icon_dir = "icons/azure"

--- a/architectures/providers/gcp/__init__.py
+++ b/architectures/providers/gcp/__init__.py
@@ -1,1 +1,0 @@
-# Make sure Python can find the packages

--- a/architectures/providers/general/__init__.py
+++ b/architectures/providers/general/__init__.py
@@ -1,1 +1,0 @@
-# Make sure Python can find the packages

--- a/architectures/providers/kubernetes/__init__.py
+++ b/architectures/providers/kubernetes/__init__.py
@@ -1,1 +1,0 @@
-# Make sure Python can find the packages

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/jsoconno/architectures",
-    packages=setuptools.find_packages(),
+    # packages=setuptools.find_packages(),
+    packages=['core', 'themes', 'providers', 'providers.aws', 'providers.azure', 'providers.gcp', 'providers.general', 'providers.kubernetes'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
In the `setup.py` file there is an argument for `packages` which was previously set to the convenient `find_packages()` function.  However, this does not seem to be picking up the sub-packages.  Testing adding them explicitly as a list.