### PR TITLE
Update code to allow for publishing of static content

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include icons *

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,34 @@
 import setuptools
-import json
-import requests
-import re
+# import json
+# import requests
+# import re
 
-def get_release_data(user, repo, field=None, regex_pattern=None, group_number=0):
-    """
-    Extract data from the latest release.
-    """
-    response = requests.get(f"https://api.github.com/repos/{user}/{repo}/releases/latest")
-    release_data_dict = json.loads(response.text)
+# def get_release_data(user, repo, field=None, regex_pattern=None, group_number=0):
+#     """
+#     Extract data from the latest release.
+#     """
+#     response = requests.get(f"https://api.github.com/repos/{user}/{repo}/releases/latest")
+#     release_data_dict = json.loads(response.text)
 
-    if field:
-        field_value = release_data_dict[field]
-        if regex_pattern is None:
-            output = field_value
-        else:
-            output = re.search(regex_pattern, field_value).group(group_number)
-    else:
-        output = release_data_dict
+#     if field:
+#         field_value = release_data_dict[field]
+#         if regex_pattern is None:
+#             output = field_value
+#         else:
+#             output = re.search(regex_pattern, field_value).group(group_number)
+#     else:
+#         output = release_data_dict
 
-    return output
+#     return output
 
-version = get_release_data(user="jsoconno", repo="architectures", field="tag_name", regex_pattern="[0-9]*\.[0-9]*\.[0-9]*")
+# version = get_release_data(user="jsoconno", repo="architectures", field="tag_name", regex_pattern="[0-9]*\.[0-9]*\.[0-9]*")
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="architectures",
-    version=version,
+    version='0.2.6',
     author="Justin O'Connor",
     author_email="jsoconno@gmail.com",
     description="Tools for creating architecture as code using Python.",
@@ -36,6 +36,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/jsoconno/architectures",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="architectures",
-    version='0.2.6',
+    version=version,
     author="Justin O'Connor",
     author_email="jsoconno@gmail.com",
     description="Tools for creating architecture as code using Python.",

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,27 @@
 import setuptools
-# import json
-# import requests
-# import re
+import json
+import requests
+import re
 
-# def get_release_data(user, repo, field=None, regex_pattern=None, group_number=0):
-#     """
-#     Extract data from the latest release.
-#     """
-#     response = requests.get(f"https://api.github.com/repos/{user}/{repo}/releases/latest")
-#     release_data_dict = json.loads(response.text)
+def get_release_data(user, repo, field=None, regex_pattern=None, group_number=0):
+    """
+    Extract data from the latest release.
+    """
+    response = requests.get(f"https://api.github.com/repos/{user}/{repo}/releases/latest")
+    release_data_dict = json.loads(response.text)
 
-#     if field:
-#         field_value = release_data_dict[field]
-#         if regex_pattern is None:
-#             output = field_value
-#         else:
-#             output = re.search(regex_pattern, field_value).group(group_number)
-#     else:
-#         output = release_data_dict
+    if field:
+        field_value = release_data_dict[field]
+        if regex_pattern is None:
+            output = field_value
+        else:
+            output = re.search(regex_pattern, field_value).group(group_number)
+    else:
+        output = release_data_dict
 
-#     return output
+    return output
 
-# version = get_release_data(user="jsoconno", repo="architectures", field="tag_name", regex_pattern="[0-9]*\.[0-9]*\.[0-9]*")
+version = get_release_data(user="jsoconno", repo="architectures", field="tag_name", regex_pattern="[0-9]*\.[0-9]*\.[0-9]*")
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
A `MANIFEST.in` file was added to specific that all content under the icons folder should be included in the distribution.  `setup.py` was also updated with an additional attribute `include_package_data=True` to let Python know it should look at the `MANIFEST.in` file for the package data to include.