### PR TITLE
Add requirement to install graphviz in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,9 @@ setuptools.setup(
     url="https://github.com/jsoconno/architectures",
     packages=setuptools.find_packages(),
     include_package_data=True,
+    install_requires = [
+        "graphviz",
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
The `install_requires` argument was added to the `setup.py` file to ensure it is installed.